### PR TITLE
fix: Fixed Backend for Register

### DIFF
--- a/TMS/app/Actions/Fortify/CreateNewUser.php
+++ b/TMS/app/Actions/Fortify/CreateNewUser.php
@@ -20,14 +20,18 @@ class CreateNewUser implements CreatesNewUsers
     public function create(array $input): User
     {
         Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
+            'first_name' => ['required', 'string', 'max:255'],
+            'last_name' => ['required', 'string', 'max:255'],
+            'suffix' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => $this->passwordRules(),
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',
         ])->validate();
 
         return User::create([
-            'name' => $input['name'],
+            'first_name' => $input['first_name'],
+            'last_name' => $input['last_name'],
+            'suffix' => $input['suffix'],
             'email' => $input['email'],
             'password' => Hash::make($input['password']),
         ]);

--- a/TMS/app/Models/User.php
+++ b/TMS/app/Models/User.php
@@ -24,7 +24,9 @@ class User extends Authenticatable implements MustVerifyEmail
      * @var array<int, string>
      */
     protected $fillable = [
-        'name',
+        'first_name',
+        'last_name',
+        'suffix',
         'email',
         'password',
     ];

--- a/TMS/database/factories/UserFactory.php
+++ b/TMS/database/factories/UserFactory.php
@@ -27,7 +27,8 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
+            'first_name' => fake()->firstName(),
+            'last_name' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),

--- a/TMS/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/TMS/database/migrations/0001_01_01_000000_create_users_table.php
@@ -13,7 +13,9 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('suffix');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');

--- a/TMS/database/seeders/DatabaseSeeder.php
+++ b/TMS/database/seeders/DatabaseSeeder.php
@@ -16,7 +16,7 @@ class DatabaseSeeder extends Seeder
         // User::factory(10)->create();
 
         User::factory()->create([
-            'name' => 'Test User',
+            'first_name' => 'Test User',
             'email' => 'test@example.com',
         ]);
     }

--- a/TMS/resources/views/navigation-menu.blade.php
+++ b/TMS/resources/views/navigation-menu.blade.php
@@ -82,7 +82,7 @@
                             @else
                                 <span class="inline-flex rounded-md">
                                     <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none focus:bg-gray-50 active:bg-gray-50 transition ease-in-out duration-150">
-                                        {{ Auth::user()->name }}
+                                        {{ Auth::user()->first_name }}
 
                                         <svg class="ms-2 -me-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                             <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />


### PR DESCRIPTION
Changes made:
in CreateNewUser.php
![image](https://github.com/user-attachments/assets/37cb860c-6e57-4115-8892-0fccb1281f07)
This line of code shows the validation you require for the User class, changed the validation of "name" to first name, last name, suffix since i've removed name from User table.
![image](https://github.com/user-attachments/assets/4114bf21-a878-45e4-9945-86bc55c93adc)
This line of code shows the User Creation part and which ones are inserted into the table by using ::create method, i've removed name and added first_name, last_name and  suffix, will remove required restriction on suffix on the next few pushes.
in Models/User.php
![image](https://github.com/user-attachments/assets/5c6a6409-caaf-411c-81b7-1818be7aa579)
The ones that can be mass assigned are under $fillable, simply removed name and added first_name last_name suffx, this is mainly for faker() which is the automatic test data in laravel.
 in UserFactory
![image](https://github.com/user-attachments/assets/5a8deb64-f3ed-42f3-be4f-c048d2728a5b)
changed name to create random first names and last names, this is the tool used to create test data.
in Migrations
![image](https://github.com/user-attachments/assets/55216212-8faf-49b5-891d-059f5fef5b7b)
Changed migration structure, to receive the changes in your database table itself, you might need to 
**php artisan migrate:fresh**
![image](https://github.com/user-attachments/assets/2198a5f7-bcd8-4f19-98bd-5f615cef338c)
Database seeders are just test data creation for new tables, changed values from name to first_name.
same with navigation since it's trying to find a name that doesnt exist within the User class.
